### PR TITLE
#9 adding support for MultiLangSnip titles

### DIFF
--- a/docs-asciidoc-extensions/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/docs-asciidoc-extensions/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -86,7 +86,7 @@ class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttribu
                 content << """
 [source.multi-language-sample,$lang]
 ----
-${includes.join("\n")}
+${includes.join("\n\n")}
 ----"""
             }
         }

--- a/docs-asciidoc-extensions/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/docs-asciidoc-extensions/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -50,6 +50,7 @@ class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttribu
     protected Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         String[] tags = valueAtAttributes("tags", attributes)?.toString()?.split(",")
         String indent = valueAtAttributes("indent", attributes)
+        String title = valueAtAttributes("title", attributes)
         StringBuilder content = new StringBuilder()
 
         String[] files = target.split(",")
@@ -75,6 +76,10 @@ class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttribu
                 } else {
                     includes << "include::${file.absolutePath}[${indent}]"
                 }
+            }
+
+            if (title != null) {
+                content << ".$title\n"
             }
 
             if (!includes.empty) {


### PR DESCRIPTION
This PR solves an issue with https://github.com/micronaut-projects/micronaut-core/issues/1265, where `include::` tags with a `.Title Over the Example` (which are utilized frequently) cannot be converted 1-for-1 to MultiLanguage `snippet::`s, as the snippet macro neutralizes the title. 

The solution allows for specifying a title for each snippet, providing high-level context to the snippet (especially when many snippets are included one after the other, as the titles help highlight key differences)